### PR TITLE
Add assertions to code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,4 +66,5 @@ javafx {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/sisyphus/Sisyphus.java
+++ b/src/main/java/sisyphus/Sisyphus.java
@@ -34,6 +34,7 @@ public class Sisyphus {
         while (isChatting) {
             try {
                 String fullCommand = ui.readLine();
+                assert fullCommand != null : "Ensure line was read correctly";
                 parser.runCommand(fullCommand, tasks, storage, ui);
                 isChatting = parser.getActiveStatus();
             } catch (SisyphusException e) {

--- a/src/main/java/sisyphus/parser/Parser.java
+++ b/src/main/java/sisyphus/parser/Parser.java
@@ -110,6 +110,7 @@ public class Parser {
                         + "todo Roll Boulder");
             }
             ToDo todoTask = new ToDo(params);
+            assert todoTask != null : "Ensure that deadline is created";
             taskList.addTask(todoTask);
             storage.writeFile(taskList);
             output = ui.printAddTodo(taskList);
@@ -129,6 +130,7 @@ public class Parser {
             }
 
             Deadline deadlineTask = new Deadline(description, deadlineDate);
+            assert deadlineTask != null : "Ensure that deadline is created";
             taskList.addTask(deadlineTask);
             storage.writeFile(taskList);
             output = ui.printAddDeadline(taskList);
@@ -150,6 +152,7 @@ public class Parser {
             }
 
             Event eventTask = new Event(description, from, to);
+            assert eventTask != null : "Ensure that event is created";
             taskList.addTask(eventTask);
             storage.writeFile(taskList);
             output = ui.printAddEvent(taskList);

--- a/src/main/java/sisyphus/storage/Storage.java
+++ b/src/main/java/sisyphus/storage/Storage.java
@@ -105,6 +105,7 @@ public class Storage {
                 stringBuilder.append(taskList.getTask(i).toSaveFormat());
                 stringBuilder.append('\n');
             }
+            assert fileWriter != null : "Ensure that fileWriter is instantiated to be written";
             fileWriter.write(stringBuilder.toString());
             fileWriter.close();
         } catch (IOException e) {


### PR DESCRIPTION
This commit introduces assertions to the codebase by enabling it in `gradle.build`.

There are several methods in the code that should hold at various points to ensure the safety of our program. This includes certain uninstantialised objects which could be null values.

By using assertions, we are able to put assertion points that ensure our variables are not null values.